### PR TITLE
Add search for files and folders

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,21 @@
     <title>B2-tree-browser</title>
   </head>
   <body>
-    <h1 class="text-center">B2-tree-browser</h1>
-    <input list="files" autocomplete="off" onchange="expandSearch(this.value)" type="text" placeholder="Search files and folders" id="search" >
+    <!-- The following nav is modified from a snippet published on the website stackoverflow https://stackoverflow.com/a/43738936 and is licensed as CC BY-SA 4.0 (https://creativecommons.org/licenses/by-sa/4.0/). The original stackoverflow anwser was made by Zim (https://stackoverflow.com/users/171456/zim) that was additionally modified by URL Rewriter Bot  -->
+    <nav class="navbar navbar-expand-lg">
+      <div class="navbar-nav mx-auto">
+        <span class="navbar-brand">B2-tree-browser</span>
+        <input
+          class="form-control text-center"
+          list="files"
+          autocomplete="off"
+          onchange="expandSearch(this.value)"
+          type="text"
+          placeholder="Search files and folders"
+          id="search"
+        />
+      </div>
+    </nav>
     <div class="container-fluid">
       <div class="row justify-content-lg-center">
         <nav id="tree" class="border border-primary rounded col-lg-4">

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
   </head>
   <body>
     <h1 class="text-center">B2-tree-browser</h1>
+    <input list="files" autocomplete="off" onchange="expandSearch(this.value)" type="text" placeholder="Search files and folders" id="search" >
     <div class="container-fluid">
       <div class="row justify-content-lg-center">
         <nav id="tree" class="border border-primary rounded col-lg-4">

--- a/js/tree.js
+++ b/js/tree.js
@@ -7,7 +7,7 @@ var foldername = "";
 var path = "";
 var datalist = "";
 var branch = null;
-const isDesktop = () => (screen.width >= 992);
+const isDesktop = () => screen.width >= 992;
 
 const imageFileExtension = [
   "gif",
@@ -65,7 +65,7 @@ function traverse(obj) {
           path += foldername + "/";
           folderlength = foldername.length + 1;
           body += "<details><summary>" + foldername + "</summary>";
-          datalist += (`<option value="${path}" label="${foldername}">`);
+          datalist += `<option value="${path}" label="${foldername}">`;
           traverse(obj[k]);
           path = path.slice(0, path.length - folderlength);
           body += "</details>";
@@ -81,7 +81,7 @@ function traverse(obj) {
     if (filetype == "file") {
       let url = urlPrefix;
       url += encodeS3URI(path + obj);
-      datalist += (`<option value="${path + obj}" label="${obj}">`);
+      datalist += `<option value="${path + obj}" label="${obj}">`;
 
       body += '<a href="' + url + '" target="_blank">' + obj + "</a>" + "<br/>";
     }
@@ -100,7 +100,12 @@ async function getTree() {
 
   traverse(jdata[0]);
   document.getElementById("tree").innerHTML = body;
-  document.getElementById("search").insertAdjacentHTML("afterend", `<datalist id="files"> ${datalist} </datalist>`);
+  document
+    .getElementById("search")
+    .insertAdjacentHTML(
+      "afterend",
+      `<datalist id="files"> ${datalist} </datalist>`
+    );
 }
 
 // This function 'interceptClicks()' is modified from a snippet published on the website stackoverflow (https://stackoverflow.com/a/21518470) and is licensed as CC BY-SA 4.0 (https://creativecommons.org/licenses/by-sa/4.0/). The original stackoverflow anwser was made by Matt Way (https://stackoverflow.com/users/277697/matt-way) that was additionally modified by user2742371.
@@ -160,7 +165,7 @@ const interceptClicks = async () => {
 interceptClicks();
 
 function expandSearch(path) {
-  if(branch) {
+  if (branch) {
     // Remove highlight of previous search
     branch.classList.remove("bg-warning");
   }
@@ -168,9 +173,9 @@ function expandSearch(path) {
   branch = document.getElementById("tree");
 
   // Expand the tree to the desired file
-  for(f of path.split("/").slice(0, -1)) {    
-    for(b of branch.children) {      
-      if(b?.firstElementChild?.innerText === f) {
+  for (f of path.split("/").slice(0, -1)) {
+    for (b of branch.children) {
+      if (b?.firstElementChild?.innerText === f) {
         b.setAttribute("open", "");
         branch = b;
         break;
@@ -178,13 +183,14 @@ function expandSearch(path) {
     }
   }
 
-  if(path.split("/").slice(-1)[0] !== "") {
+  if (path.split("/").slice(-1)[0] !== "") {
     // Highlight the desired file
-    for(b of branch.getElementsByTagName("a")) {
-      if(b.innerText === path.split("/").slice(-1)[0]) {
+    for (b of branch.getElementsByTagName("a")) {
+      if (b.innerText === path.split("/").slice(-1)[0]) {
         b.classList.add("bg-warning");
-        if(isDesktop()) b.click(); // On desktop, auto load file into object.
+        if (isDesktop()) b.click(); // On desktop, auto load file into object.
         branch = b;
+        if (!isDesktop()) document.getElementById("search").value = "";
         break;
       }
     }
@@ -192,5 +198,4 @@ function expandSearch(path) {
     // User searched for folder, not file
     branch.classList.add("bg-warning");
   }
-
 }

--- a/js/tree.js
+++ b/js/tree.js
@@ -5,6 +5,8 @@ var body = "";
 var filetype = "";
 var foldername = "";
 var path = "";
+var datalist = "";
+var branch = null;
 
 const imageFileExtension = [
   "gif",
@@ -62,6 +64,7 @@ function traverse(obj) {
           path += foldername + "/";
           folderlength = foldername.length + 1;
           body += "<details><summary>" + foldername + "</summary>";
+          datalist += (`<option value="${path}" label="${foldername}">`);
           traverse(obj[k]);
           path = path.slice(0, path.length - folderlength);
           body += "</details>";
@@ -77,6 +80,7 @@ function traverse(obj) {
     if (filetype == "file") {
       let url = urlPrefix;
       url += encodeS3URI(path + obj);
+      datalist += (`<option value="${path + obj}" label="${obj}">`);
 
       body += '<a href="' + url + '" target="_blank">' + obj + "</a>" + "<br/>";
     }
@@ -95,6 +99,7 @@ async function getTree() {
 
   traverse(jdata[0]);
   document.getElementById("tree").innerHTML = body;
+  document.getElementById("search").insertAdjacentHTML("afterend", `<datalist id="files"> ${datalist} </datalist>`);
 }
 
 // This function 'interceptClicks()' is modified from a snippet published on the website stackoverflow (https://stackoverflow.com/a/21518470) and is licensed as CC BY-SA 4.0 (https://creativecommons.org/licenses/by-sa/4.0/). The original stackoverflow anwser was made by Matt Way (https://stackoverflow.com/users/277697/matt-way) that was additionally modified by user2742371.
@@ -152,3 +157,38 @@ const interceptClicks = async () => {
 };
 
 interceptClicks();
+
+function expandSearch(path) {
+  if(branch) {
+    // Remove highlight of previous search
+    branch.classList.remove("bg-warning");
+  }
+
+  branch = document.getElementById("tree");
+
+  // Expand the tree to the desired file
+  for(f of path.split("/").slice(0, -1)) {    
+    for(b of branch.children) {      
+      if(b?.firstElementChild?.innerText === f) {
+        b.setAttribute("open", "");
+        branch = b;
+        break;
+      }
+    }
+  }
+
+  if(path.split("/").slice(-1)[0] !== "") {
+    // Highlight the desired file
+    for(b of branch.getElementsByTagName("a")) {
+      if(b.innerText === path.split("/").slice(-1)[0]) {
+        b.classList.add("bg-warning");
+        branch = b;
+        break;
+      }
+    }
+  } else {
+    // User searched for folder, not file
+    branch.classList.add("bg-warning");
+  }
+
+}

--- a/js/tree.js
+++ b/js/tree.js
@@ -7,6 +7,7 @@ var foldername = "";
 var path = "";
 var datalist = "";
 var branch = null;
+const isDesktop = () => (screen.width >= 992);
 
 const imageFileExtension = [
   "gif",
@@ -105,7 +106,7 @@ async function getTree() {
 // This function 'interceptClicks()' is modified from a snippet published on the website stackoverflow (https://stackoverflow.com/a/21518470) and is licensed as CC BY-SA 4.0 (https://creativecommons.org/licenses/by-sa/4.0/). The original stackoverflow anwser was made by Matt Way (https://stackoverflow.com/users/277697/matt-way) that was additionally modified by user2742371.
 const interceptClicks = async () => {
   const result = await getTree();
-  if (screen.width >= 992) {
+  if (isDesktop()) {
     // This part of the function is modified from a snippet published on the website codeproject (https://www.codeproject.com/Answers/525918/Displaypluscontentplusofpluslinkplusinplusparticul#answer1). The original codeproject anwser was made by ramukhsakarp (https://www.codeproject.com/script/Membership/View.aspx?mid=7652198).
     $(document).ready(function () {
       $("#tree a").click(function (e) {
@@ -182,6 +183,7 @@ function expandSearch(path) {
     for(b of branch.getElementsByTagName("a")) {
       if(b.innerText === path.split("/").slice(-1)[0]) {
         b.classList.add("bg-warning");
+        if(isDesktop()) b.click(); // On desktop, auto load file into object.
         branch = b;
         break;
       }


### PR DESCRIPTION
This PR adds search for files and folders. 

Tested on:
* Windows 10, Chrome 86.0.4240.111 (success)
* Windows 10, Firefox 82.0 (success)
* Android 10, Chrome 86.0.4240.111 (success)
* Android 10, Firefox 81.1.5, GV 81.0.2 (fail: GeckoView on mobile does not support datalists)

Styling still needs some fixes.
